### PR TITLE
Implement configurable User un Admin commands 

### DIFF
--- a/src/main/java/world/bentobox/bskyblock/Settings.java
+++ b/src/main/java/world/bentobox/bskyblock/Settings.java
@@ -30,6 +30,17 @@ import world.bentobox.bentobox.database.objects.adapters.FlagSerializer2;
 @ConfigComment("BSkyBlock Configuration [version]")
 public class Settings implements DataObject, WorldSettings {
 
+    /* Commands */
+    @ConfigComment("Island Command. What command users will run to access their island.")
+    @ConfigComment("To define alias, just separate commands with white space.")
+    @ConfigEntry(path = "bskyblock.command.island")
+    private String islandCommand = "island is";
+
+    @ConfigComment("The island admin command.")
+    @ConfigComment("To define alias, just separate commands with white space.")
+    @ConfigEntry(path = "bskyblock.command.admin")
+    private String adminCommand = "bsbadmin bsb";
+
     /*      WORLD       */
     @ConfigComment("Friendly name for this world. Used in admin commands. Must be a single word")
     @ConfigEntry(path = "world.friendly-name")
@@ -1099,5 +1110,47 @@ public class Settings implements DataObject, WorldSettings {
      */
     public void setBanLimit(int banLimit) {
         this.banLimit = banLimit;
+    }
+
+
+    /**
+     * This method returns the islandCommand value.
+     * @return the value of islandCommand.
+     */
+    public String getIslandCommand()
+    {
+        return islandCommand;
+    }
+
+
+    /**
+     * This method sets the islandCommand value.
+     * @param islandCommand the islandCommand new value.
+     *
+     */
+    public void setIslandCommand(String islandCommand)
+    {
+        this.islandCommand = islandCommand;
+    }
+
+
+    /**
+     * This method returns the adminCommand value.
+     * @return the value of adminCommand.
+     */
+    public String getAdminCommand()
+    {
+        return adminCommand;
+    }
+
+
+    /**
+     * This method sets the adminCommand value.
+     * @param adminCommand the adminCommand new value.
+     *
+     */
+    public void setAdminCommand(String adminCommand)
+    {
+        this.adminCommand = adminCommand;
     }
 }

--- a/src/main/java/world/bentobox/bskyblock/commands/AdminCommand.java
+++ b/src/main/java/world/bentobox/bskyblock/commands/AdminCommand.java
@@ -29,7 +29,9 @@ import world.bentobox.bskyblock.BSkyBlock;
 public class AdminCommand extends CompositeCommand {
 
     public AdminCommand(BSkyBlock addon) {
-        super(addon, "bsbadmin", "bsb");
+        super(addon,
+            addon.getSettings().getAdminCommand().split(" ")[0],
+            addon.getSettings().getAdminCommand().split(" "));
     }
 
     @Override

--- a/src/main/java/world/bentobox/bskyblock/commands/IslandCommand.java
+++ b/src/main/java/world/bentobox/bskyblock/commands/IslandCommand.java
@@ -25,7 +25,9 @@ import world.bentobox.bskyblock.BSkyBlock;
 public class IslandCommand extends CompositeCommand {
 
     public IslandCommand(BSkyBlock addon) {
-        super(addon, "island", "is");
+        super(addon,
+            addon.getSettings().getIslandCommand().split(" ")[0],
+            addon.getSettings().getIslandCommand().split(" "));
     }
 
     /* (non-Javadoc)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,12 @@
 # BSkyBlock Configuration ${version}
+bskyblock:
+  command:
+    # Island Command. What command users will run to access their island.
+    # To define alias, just separate commands with white space.
+    island: island is
+    # The island admin command.
+    # To define alias, just separate commands with white space.
+    admin: bsbadmin bsb
 world:
   # Friendly name for this world. Used in admin commands. Must be a single word
   friendly-name: BSkyBlock


### PR DESCRIPTION
Add 2 new options in config.yml:
bskyblock.command.admin and bskyblock.command.user
These will allow customizing command call for bSkyBlock.
Fixes issue #77 