### PR TITLE
Add build number in addon.yml

### DIFF
--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -1,6 +1,6 @@
 name: BSkyBlock
 main: world.bentobox.bskyblock.BSkyBlock
-version: ${version}
+version: ${version}${build.number}
 metrics: true
 icon: "OAK_SAPLING"
 repository: "BentoBoxWorld/BSkyBlock"


### PR DESCRIPTION
This will allow seeing build number in ./bentobox v output.