### PR TITLE
Add informative messages to the options.

### DIFF
--- a/src/main/java/world/bentobox/bskyblock/Settings.java
+++ b/src/main/java/world/bentobox/bskyblock/Settings.java
@@ -191,6 +191,7 @@ public class Settings implements WorldSettings {
     @ConfigComment("This option indicates if nether portals should be linked via dimensions.")
     @ConfigComment("Option will simulate vanilla portal mechanics that links portals together")
     @ConfigComment("or creates a new portal, if there is not a portal in that dimension.")
+    @ConfigComment("This option requires `allow-nether=true` in server.properties.")
     @ConfigEntry(path = "world.nether.create-and-link-portals", since = "1.14.4")
     private boolean makeNetherPortals = false;
 
@@ -206,6 +207,7 @@ public class Settings implements WorldSettings {
 
     @ConfigComment("This option indicates if obsidian platform in the end should be generated")
     @ConfigComment("when player enters the end world.")
+    @ConfigComment("This option requires `allow-end=true` in bukkit.yml.")
     @ConfigEntry(path = "world.end.create-obsidian-platform", since = "1.14.4")
     private boolean makeEndPortals = false;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -119,6 +119,7 @@ world:
     # This option indicates if nether portals should be linked via dimensions.
     # Option will simulate vanilla portal mechanics that links portals together
     # or creates a new portal, if there is not a portal in that dimension.
+    # This option requires `allow-nether=true` in server.properties.
     # Added since 1.14.4.
     create-and-link-portals: false
   end:
@@ -130,6 +131,7 @@ world:
     islands: true
     # This option indicates if obsidian platform in the end should be generated
     # when player enters the end world.
+    # This option requires `allow-end=true` in bukkit.yml.
     # Added since 1.14.4.
     create-obsidian-platform: false
     # /!\ This feature is experimental and might not work as expected or might not work at all.


### PR DESCRIPTION
Options that has extra info:
`create-and-link-portals` works only if allow-nether is enabled.
`create-obsidian-platform` works only if allow-end is enabled.