### PR TITLE
Fixing a possible bug that can interfere with mob spawns in bskyblock generated worlds

### DIFF
--- a/src/main/java/world/bentobox/bskyblock/generators/ChunkGeneratorWorld.java
+++ b/src/main/java/world/bentobox/bskyblock/generators/ChunkGeneratorWorld.java
@@ -12,6 +12,7 @@ import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.WorldInfo;
 import org.bukkit.util.Vector;
 import org.bukkit.util.noise.PerlinOctaveGenerator;
 
@@ -70,6 +71,11 @@ public class ChunkGeneratorWorld extends ChunkGenerator {
     // behavior
     @Override
     public boolean canSpawn(World world, int x, int z) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldGenerateMobs(WorldInfo worldInfo, Random random, int chunkX, int chunkZ){
         return true;
     }
 


### PR DESCRIPTION
ChunkGenerator has a boolean called shouldGenerateMobs() and has the description, "Gets if the server should generate Vanilla mobs after this ChunkGenerator."

I've worked a couple of days ago with a custom world generator and I noticed the default mob spawn was not behaving right. I was on hard diff with 0 light level on the entire map and there were very few spawns. I found out that if you don't override shouldGenerateMobs() is just returns false by default. 
It does seem to interfere with normal mob spawn in certain cases, but not always which seems very strange to me. But I do remember running BSkyBlock and having mob spawn issues for no real reason, I've also seen people complain about this kind of stuff in the discord as well. 

Needs some testing, and perhaps digging through src to find out what's really happening. Though I doubt just leaving this setting on true would have any negative effects. 