### PR TITLE
ci: bump pinned publish-platforms.yml to ca2dcd1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "SkyBlock-BSkyBlock"           # blank = skip Hangar


### PR DESCRIPTION
Bumps the pinned `bentoboxworld/.github` reusable workflow (`publish-platforms.yml`) from `fe4b1f0` to `ca2dcd1`.

This picks up [BentoBoxWorld/.github#12](https://github.com/BentoBoxWorld/.github/pull/12): CurseForge release-note changelogs are now uploaded as **HTML** (rendered from the release markdown via GitHub's `/markdown` API) instead of `changelogType: markdown`, which CurseForge was displaying with every markdown character backslash-escaped. Also strips CRLF from the changelog so all platforms get clean text.

No behaviour change for this repo beyond the fixed CurseForge changelog formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)