### PR TITLE
ci: bump publish-platforms pin to the multipart-JSON fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@1f91a0edf72e8c86d671b3b8fdd3121ac6fb88e1 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "SkyBlock-BSkyBlock"           # blank = skip Hangar


### PR DESCRIPTION
## What

Bumps the pinned SHA of the shared `publish-platforms.yml` reusable workflow to `1f91a0e` (master HEAD of `BentoBoxWorld/.github`).

## Why

The pinned version passes the CurseForge `metadata` and Hangar `versionUpload` multipart JSON as an inline curl value:

```
-F "metadata=${META};type=application/json"
```

curl reads a `;` inside an inline `-F` value as the start of a `type=`/`filename=` attribute, so the JSON is silently truncated at the first semicolon in the release body. Both platforms then reject the upload:

- CurseForge — `{"errorCode":1002,"errorMessage":"Error in field \`metadata\`: Invalid JSON."}`
- Hangar — `{"status":400,"detail":"Failed to read request"}`

This is latent, not theoretical: it took down the AOneBlock 1.26.3 publish ([run](https://github.com/BentoBoxWorld/AOneBlock/actions/runs/30468254213)) because those release notes happened to contain one semicolon. Any release body with a semicolon in it trips this.

BentoBoxWorld/.github#13 fixed it on 2026-07-20 by writing the JSON to a file and using curl's `<file` form (`-F "metadata=<cf_meta.json;type=application/json"`). This repo was still pinned to the commit before that fix.

Modrinth publishing is unaffected — it does not go through this workflow.

No behaviour change beyond the fix; the pin is the only line touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAQ3YQkcfRoCZEwa6SPJcp
